### PR TITLE
Refactor home experience with hero-led flow

### DIFF
--- a/src/react-app/components/layout/ExperienceOverlay.tsx
+++ b/src/react-app/components/layout/ExperienceOverlay.tsx
@@ -1,0 +1,96 @@
+import { ReactNode, useEffect } from 'react';
+import { X } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+interface ExperienceOverlayProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function ExperienceOverlay({
+  open,
+  title,
+  description,
+  icon: Icon,
+  onClose,
+  children,
+}: ExperienceOverlayProps) {
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8">
+      <div
+        className="absolute inset-0 bg-slate-950/80 backdrop-blur-xl"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal
+        aria-labelledby="experience-overlay-title"
+        className="relative w-full max-w-5xl overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-2xl backdrop-blur-2xl glass-surface"
+      >
+        <div className="absolute -top-40 -left-32 h-80 w-80 rounded-full bg-emerald-500/20 blur-3xl" aria-hidden="true" />
+        <div className="absolute -bottom-32 -right-20 h-72 w-72 rounded-full bg-cyan-500/20 blur-3xl" aria-hidden="true" />
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-6 top-6 rounded-full border border-white/10 bg-white/10 p-2 text-white transition hover:bg-white/20"
+          aria-label="Fechar visualização"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <div className="relative flex flex-col gap-6">
+          <div className="flex flex-col gap-4 pr-12 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-4">
+              {Icon && (
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-500 via-sky-500 to-blue-600 text-white shadow-lg">
+                  <Icon className="h-6 w-6" />
+                </span>
+              )}
+              <div>
+                <h2 id="experience-overlay-title" className="text-2xl font-semibold text-white">
+                  {title}
+                </h2>
+                {description && (
+                  <p className="mt-2 max-w-2xl text-sm text-slate-200/80">
+                    {description}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="relative max-h-[70vh] overflow-y-auto pr-2 text-left">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/react-app/components/sections/CallToActionSection.tsx
+++ b/src/react-app/components/sections/CallToActionSection.tsx
@@ -1,0 +1,50 @@
+import { ArrowRight, Shield } from 'lucide-react';
+import type { OverlayView } from './FinancePreviewSection';
+
+interface CallToActionSectionProps {
+  onOpenOverlay: (view: OverlayView) => void;
+}
+
+export default function CallToActionSection({ onOpenOverlay }: CallToActionSectionProps) {
+  return (
+    <section className="relative mt-24 pb-20 text-left">
+      <div className="absolute inset-x-0 -bottom-40 -z-10 h-[400px] bg-gradient-to-b from-emerald-500/20 via-transparent to-transparent blur-3xl" aria-hidden="true" />
+      <div className="overflow-hidden rounded-4xl border border-white/10 bg-slate-900/70 p-10 shadow-2xl backdrop-blur-xl glass-surface">
+        <div className="absolute -left-20 top-1/2 h-48 w-48 -translate-y-1/2 rounded-full bg-emerald-500/30 blur-3xl" aria-hidden="true" />
+        <div className="absolute -right-16 -top-24 h-64 w-64 rounded-full bg-cyan-500/20 blur-3xl" aria-hidden="true" />
+        <div className="relative flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-2xl">
+            <div className="flex items-center gap-3 text-emerald-200/80">
+              <Shield className="h-5 w-5" />
+              <span className="text-sm font-medium uppercase tracking-[0.3em]">Segurança e autonomia</span>
+            </div>
+            <h2 className="mt-6 text-3xl font-semibold text-white sm:text-4xl">
+              Aprofunde sua estratégia financeira com experiências guiadas, seguras e personalizadas.
+            </h2>
+            <p className="mt-4 text-base text-slate-200/80">
+              Continue explorando dashboards completos, cadastre novas despesas ou conecte instituições para desbloquear a automação total.
+            </p>
+          </div>
+          <div className="flex flex-col gap-4">
+            <button
+              type="button"
+              onClick={() => onOpenOverlay('dashboard')}
+              className="inline-flex items-center justify-between gap-4 rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-cyan-500 px-6 py-3 text-left text-base font-semibold text-slate-900 shadow-lg transition hover:shadow-xl"
+            >
+              Abrir painel financeiro completo
+              <ArrowRight className="h-5 w-5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenOverlay('quick-actions')}
+              className="inline-flex items-center justify-between gap-4 rounded-full border border-white/10 bg-white/10 px-6 py-3 text-left text-base font-medium text-white transition hover:bg-white/20"
+            >
+              Acessar ações rápidas
+              <ArrowRight className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/react-app/components/sections/FeatureHighlights.tsx
+++ b/src/react-app/components/sections/FeatureHighlights.tsx
@@ -1,0 +1,56 @@
+import type { LucideIcon } from 'lucide-react';
+
+interface Highlight {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  accent?: string;
+}
+
+interface FeatureHighlightsProps {
+  items: Highlight[];
+}
+
+export default function FeatureHighlights({ items }: FeatureHighlightsProps) {
+  return (
+    <section aria-labelledby="feature-highlights" className="relative">
+      <div className="mb-12 flex flex-col gap-4 text-left">
+        <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-medium uppercase tracking-[0.2em] text-emerald-200/80">
+          Experiências Financeiras
+        </span>
+        <div className="max-w-2xl">
+          <h2 id="feature-highlights" className="text-3xl font-semibold text-white sm:text-4xl">
+            Tudo o que você precisa para navegar seu dinheiro com clareza
+          </h2>
+          <p className="mt-4 text-base text-slate-200/80">
+            Explore camadas de informações, automações inteligentes e uma visão unificada das suas contas em um fluxo contínuo.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        {items.map(({ icon: Icon, title, description, accent }) => (
+          <article
+            key={title}
+            className="group relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-transparent p-6 text-left shadow-lg transition-transform hover:-translate-y-1 hover:shadow-2xl glass-surface"
+          >
+            <div
+              className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+              aria-hidden="true"
+              style={{
+                background: accent || 'linear-gradient(135deg, rgba(16, 185, 129, 0.25), rgba(20, 184, 166, 0.1))',
+              }}
+            />
+            <div className="relative flex flex-col gap-4">
+              <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/10 text-white shadow-inner">
+                <Icon className="h-6 w-6" />
+              </span>
+              <h3 className="text-lg font-semibold text-white">{title}</h3>
+              <p className="text-sm text-slate-200/70">{description}</p>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/react-app/components/sections/FinancePreviewSection.tsx
+++ b/src/react-app/components/sections/FinancePreviewSection.tsx
@@ -1,0 +1,180 @@
+import { ArrowUpRight, BarChart3, Brain, CreditCard, Sparkles, Wallet2, Zap } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { formatCurrency, formatDate } from '@/react-app/utils';
+import type { Expense } from '@/shared/types';
+
+export type OverlayView =
+  | 'dashboard'
+  | 'expense-tracker'
+  | 'transactions'
+  | 'categories'
+  | 'accounts'
+  | 'credit-cards'
+  | 'investments'
+  | 'loans'
+  | 'banking'
+  | 'insights'
+  | 'analytics'
+  | 'notifications'
+  | 'quick-actions';
+
+interface FinancePreviewSectionProps {
+  expenses: Expense[];
+  thisMonthExpenses: number;
+  totalExpenses: number;
+  avgDailySpending: number;
+  onOpenOverlay: (view: OverlayView) => void;
+}
+
+export default function FinancePreviewSection({
+  expenses,
+  thisMonthExpenses,
+  totalExpenses,
+  avgDailySpending,
+  onOpenOverlay,
+}: FinancePreviewSectionProps) {
+  const lastExpense = expenses[0];
+  const categoryTotals = expenses.reduce<Record<string, number>>((acc, expense) => {
+    acc[expense.category] = (acc[expense.category] || 0) + expense.amount;
+    return acc;
+  }, {});
+  const topCategory = Object.entries(categoryTotals).sort((a, b) => b[1] - a[1])[0];
+
+  const previewCards = [
+    {
+      id: 'expense-tracker' as const,
+      title: 'Gastos em tempo real',
+      description: 'Capture despesas em poucos cliques e visualize o impacto instantaneamente.',
+      icon: Wallet2,
+      highlight: `Este mês: ${formatCurrency(thisMonthExpenses)}`,
+      detail: lastExpense
+        ? `Último gasto em ${formatDate(lastExpense.date)} — ${formatCurrency(lastExpense.amount)} (${lastExpense.category})`
+        : 'Nenhum gasto cadastrado ainda',
+    },
+    {
+      id: 'analytics' as const,
+      title: 'Análises avançadas',
+      description: 'Aprofunde-se em gráficos dinâmicos e acompanhamento por categoria.',
+      icon: BarChart3,
+      highlight: `${expenses.length} movimentações • média de ${formatCurrency(avgDailySpending || 0)}`,
+      detail: topCategory
+        ? `Maior foco em ${topCategory[0]} — ${formatCurrency(topCategory[1])}`
+        : 'Comece registrando gastos para descobrir padrões',
+    },
+    {
+      id: 'insights' as const,
+      title: 'Insights com IA',
+      description: 'Receba sugestões proativas e inteligência personalizada sobre seus hábitos.',
+      icon: Brain,
+      highlight: 'Recomendações automatizadas',
+      detail: 'Atualize para receber novos diagnósticos sempre que registrar um gasto.',
+    },
+    {
+      id: 'banking' as const,
+      title: 'Open Finance integrado',
+      description: 'Conecte contas e cartões com camadas extras de segurança e transparência.',
+      icon: Zap,
+      highlight: `Infraestrutura Pluggy pronta • ${formatCurrency(totalExpenses)} monitorados`,
+      detail: 'Simplifique conciliações e importações com poucos cliques.',
+    },
+  ];
+
+  const quickLinks: { id: OverlayView; label: string; icon: LucideIcon }[] = [
+    { id: 'dashboard', label: 'Painel financeiro', icon: Sparkles },
+    { id: 'credit-cards', label: 'Cartões & faturas', icon: CreditCard },
+    { id: 'accounts', label: 'Contas conectadas', icon: Wallet2 },
+    { id: 'investments', label: 'Investimentos', icon: ArrowUpRight },
+    { id: 'loans', label: 'Empréstimos', icon: ArrowUpRight },
+    { id: 'notifications', label: 'Central de alertas', icon: Sparkles },
+    { id: 'transactions', label: 'Transações', icon: Wallet2 },
+    { id: 'categories', label: 'Categorias', icon: ArrowUpRight },
+    { id: 'quick-actions', label: 'Ações rápidas', icon: Sparkles },
+  ];
+
+  return (
+    <section className="relative mt-24" aria-labelledby="finance-preview">
+      <div className="absolute inset-0 -z-10 rounded-[3rem] bg-gradient-to-br from-emerald-500/10 via-cyan-500/5 to-transparent" aria-hidden="true" />
+      <div className="flex flex-col gap-12 text-left">
+        <div className="flex flex-col gap-4">
+          <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-emerald-500/10 px-4 py-1 text-xs font-medium uppercase tracking-[0.2em] text-emerald-200/90">
+            Visualização Imersiva
+          </span>
+          <h2 id="finance-preview" className="max-w-3xl text-3xl font-semibold text-white sm:text-4xl">
+            Explore camadas de dados, dashboards e integrações sem sair do fluxo
+          </h2>
+          <p className="max-w-2xl text-base text-slate-200/80">
+            Visualize tendências, abra painéis completos e conecte instituições com uma experiência fluida, inspirada em interfaces imersivas.
+          </p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          {previewCards.map(({ id, title, description, icon: Icon, highlight, detail }) => (
+            <article
+              key={id}
+              className="group relative overflow-hidden rounded-4xl border border-white/10 bg-slate-900/60 p-8 shadow-2xl backdrop-blur-xl transition-transform hover:-translate-y-1 hover:shadow-3xl glass-surface"
+            >
+              <div className="absolute -top-32 right-0 h-72 w-72 rounded-full bg-emerald-500/20 opacity-0 blur-3xl transition-opacity duration-300 group-hover:opacity-100" aria-hidden="true" />
+              <div className="relative flex flex-col gap-6">
+                <div className="flex items-center gap-4">
+                  <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/10 text-white">
+                    <Icon className="h-6 w-6" />
+                  </span>
+                  <div>
+                    <h3 className="text-2xl font-semibold text-white">{title}</h3>
+                    <p className="mt-1 text-sm text-emerald-200/80">{highlight}</p>
+                  </div>
+                </div>
+                <p className="text-base text-slate-200/80">{description}</p>
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-sm text-slate-100/80">
+                  {detail}
+                </div>
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => onOpenOverlay(id)}
+                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-5 py-2 text-sm font-medium text-white transition hover:bg-emerald-500/20"
+                  >
+                    Abrir experiência
+                    <ArrowUpRight className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="rounded-4xl border border-white/10 bg-white/5 p-6 text-left shadow-xl backdrop-blur-xl glass-surface">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h3 className="text-lg font-semibold text-white">Outras ferramentas disponíveis</h3>
+              <p className="text-sm text-slate-200/70">
+                Abra painéis completos ou fluxos específicos com um clique.
+              </p>
+            </div>
+            <div className="rounded-full border border-white/10 bg-emerald-500/20 px-4 py-1 text-xs font-medium uppercase tracking-[0.3em] text-emerald-200/90">
+              +{Math.max(0, quickLinks.length - 4)} experiências
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {quickLinks.map(({ id, label, icon: Icon }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => onOpenOverlay(id)}
+                className="group flex items-center justify-between gap-3 rounded-3xl border border-white/10 bg-slate-900/40 px-4 py-3 text-left text-sm font-medium text-slate-100/80 transition hover:bg-emerald-500/10 hover:text-white"
+              >
+                <span className="flex items-center gap-3">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-2xl border border-white/10 bg-white/10 text-white">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  {label}
+                </span>
+                <ArrowUpRight className="h-4 w-4 opacity-0 transition group-hover:opacity-100" />
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/react-app/components/sections/HeroSection.tsx
+++ b/src/react-app/components/sections/HeroSection.tsx
@@ -1,0 +1,142 @@
+import { RefreshCw, Sparkles, Wallet } from 'lucide-react';
+import AuthButton from '@/react-app/components/AuthButton';
+import type { OverlayView } from './FinancePreviewSection';
+import { formatCurrency } from '@/react-app/utils';
+
+interface HeroSectionProps {
+  userName?: string | null;
+  onRefreshInsights: () => void;
+  onOpenOverlay: (view: OverlayView) => void;
+  thisMonthExpenses: number;
+  totalExpenses: number;
+}
+
+export default function HeroSection({
+  userName,
+  onRefreshInsights,
+  onOpenOverlay,
+  thisMonthExpenses,
+  totalExpenses,
+}: HeroSectionProps) {
+  const firstName = userName?.split(' ')[0];
+
+  return (
+    <section className="relative pb-24 pt-20 text-left">
+      <div className="absolute inset-x-0 top-0 -z-10 flex h-[480px] justify-center overflow-hidden" aria-hidden="true">
+        <div className="aurora-gradient" />
+      </div>
+
+      <nav className="relative mb-16 flex items-center justify-between gap-6">
+        <div className="flex items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-white shadow-lg">
+            <Wallet className="h-6 w-6" />
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200/80">Financeito</p>
+            <p className="text-sm text-slate-200/80">Fluxo financeiro com IA generativa</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onRefreshInsights}
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Atualizar insights
+          </button>
+          <AuthButton />
+        </div>
+      </nav>
+
+      <div className="relative grid items-center gap-16 lg:grid-cols-[1.1fr_1fr]">
+        <div className="flex flex-col gap-10">
+          <div className="flex flex-col gap-6">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-medium uppercase tracking-[0.4em] text-emerald-200/80">
+              Nova experiência imersiva
+            </span>
+            <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-[3.5rem] lg:leading-[1.05]">
+              Controle financeiro com IA, agora em um fluxo contínuo
+              {firstName ? `, ${firstName}` : ''}.
+            </h1>
+            <p className="max-w-2xl text-lg text-slate-200/85">
+              Uma jornada hero-led que conecta seus gastos, insights automáticos e integrações Open Finance em um layout vertical envolvente.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <button
+              type="button"
+              onClick={() => onOpenOverlay('expense-tracker')}
+              className="inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-cyan-500 px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:shadow-xl"
+            >
+              Registrar gasto agora
+              <Sparkles className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenOverlay('insights')}
+              className="inline-flex items-center gap-3 rounded-full border border-white/15 bg-white/10 px-6 py-3 text-sm font-medium text-white transition hover:bg-white/20"
+            >
+              Ver insights de IA
+            </button>
+          </div>
+
+          <dl className="grid gap-4 sm:grid-cols-2">
+            <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur-xl glass-surface">
+              <dt className="text-sm font-medium text-emerald-200/80">Monitorado neste mês</dt>
+              <dd className="text-2xl font-semibold text-white">{formatCurrency(thisMonthExpenses)}</dd>
+              <p className="text-xs text-slate-200/70">Capture gastos recorrentes e receba alertas automáticos.</p>
+            </div>
+            <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur-xl glass-surface">
+              <dt className="text-sm font-medium text-emerald-200/80">Total acompanhado</dt>
+              <dd className="text-2xl font-semibold text-white">{formatCurrency(totalExpenses)}</dd>
+              <p className="text-xs text-slate-200/70">Centralize contas, cartões e investimentos em uma única visão.</p>
+            </div>
+          </dl>
+        </div>
+
+        <div className="relative hidden min-h-[420px] items-center justify-center lg:flex">
+          <div className="absolute inset-0 -z-10 animate-pulse-slow rounded-full bg-emerald-500/20 blur-3xl" aria-hidden="true" />
+          <div className="relative flex w-full max-w-md flex-col gap-6">
+            <div className="layered-card">
+              <div className="flex items-center justify-between">
+                <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-xs font-medium text-emerald-100">Resumo diário</span>
+                <span className="text-xs text-white/60">IA ativa</span>
+              </div>
+              <div className="mt-6 space-y-4">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">Este mês</p>
+                  <p className="mt-1 text-3xl font-semibold text-white">{formatCurrency(thisMonthExpenses)}</p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/60">Recomendação</p>
+                  <p className="mt-2 text-sm text-white/80">
+                    Ajuste o orçamento da categoria com maior crescimento e abra os insights completos para sugestões personalizadas.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="layered-card translate-x-8 border-white/5 bg-white/10">
+              <div className="flex items-center justify-between text-sm text-white/70">
+                <span>Contas conectadas</span>
+                <button
+                  type="button"
+                  onClick={() => onOpenOverlay('banking')}
+                  className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs text-white transition hover:bg-white/20"
+                >
+                  Abrir Open Finance
+                </button>
+              </div>
+              <div className="mt-5 space-y-3 text-sm text-white/70">
+                <p>Carteira digital • sincronização em tempo real</p>
+                <p>Cartões vinculados • monitoramento de limites</p>
+                <p className="text-xs text-emerald-200/80">Nova integração disponível para investimentos.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/react-app/index.css
+++ b/src/react-app/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -54,12 +56,22 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground antialiased;
   }
 }
 
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Space Grotesk', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  background: radial-gradient(circle at 20% 20%, rgba(16, 185, 129, 0.2), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.2), transparent 45%),
+    radial-gradient(circle at 50% 80%, rgba(59, 130, 246, 0.15), transparent 45%),
+    #020617;
+  color: #f8fafc;
+  min-height: 100vh;
+  color-scheme: dark;
 }
 
 /* Paper texture background */
@@ -99,4 +111,76 @@
     );
   opacity: 0.4;
   pointer-events: none;
+}
+
+.bg-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-size: 40px 40px;
+  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.8) 0%, transparent 70%);
+}
+
+.aurora-gradient {
+  width: 140%;
+  height: 100%;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(16, 185, 129, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.25), transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(59, 130, 246, 0.2), transparent 55%);
+  filter: blur(60px);
+  opacity: 0.9;
+}
+
+.glass-surface {
+  position: relative;
+  backdrop-filter: blur(24px);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(148, 163, 184, 0.08));
+}
+
+.glass-surface::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  pointer-events: none;
+}
+
+.layered-card {
+  position: relative;
+  border-radius: 24px;
+  padding: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(15, 118, 110, 0.3));
+  backdrop-filter: blur(20px);
+  box-shadow: 0 25px 60px -20px rgba(15, 118, 110, 0.35);
+  color: #f8fafc;
+}
+
+.layered-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+}
+
+.animate-pulse-slow {
+  animation: pulse-slow 8s ease-in-out infinite;
+}
+
+@keyframes pulse-slow {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the tabbed home layout with a hero-driven vertical journey that surfaces highlights, previews and modals for each finance experience
- add presentation components (hero, highlights, preview, CTA) and a reusable overlay shell to stage existing dashboards inside layered cards
- refresh global styling with new fonts, gradients, glassmorphism helpers and animated backdrops for a high-contrast crafted.is-inspired feel

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d343cba970832facc6c0ae9552f8d4