### PR TITLE
Fix build configuration and React types

### DIFF
--- a/src/react-app/pages/homeConfig.tsx
+++ b/src/react-app/pages/homeConfig.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import type { ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import {
   Wallet,
@@ -69,7 +69,7 @@ interface OverlayConfigEntry {
   title: string;
   description: string;
   icon: LucideIcon;
-  render: () => JSX.Element;
+  render: () => ReactNode;
 }
 
 export type OverlayConfig = Record<OverlayView, OverlayConfigEntry>;

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -2,11 +2,11 @@
   "extends": "./tsconfig.node.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
-    "types": ["vite/client", "./worker-configuration.d.ts"],
+    "types": ["vite/client"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/worker"]
+  "include": ["src/worker", "worker-configuration.d.ts"]
 }


### PR DESCRIPTION
## Summary
- replace JSX.Element typing in the home overlay config with ReactNode to avoid missing JSX namespace errors
- adjust the worker TypeScript config to include the local worker declaration file without misusing compiler types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d35cce8894832fa0423deda8e0c10a