### PR TITLE
Fix TypeScript configuration for React and worker builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.9.6",
+        "@cloudflare/workers-types": "^4.20250317.0",
         "@eslint/js": "9.25.1",
         "@getmocha/users-service": "^0.0.4",
         "@getmocha/vite-plugins": "latest",
@@ -481,6 +482,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250924.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250924.0.tgz",
+      "integrity": "sha512-pi/OYCroYdwjFWbkciC5oYzlyimDF4ymNotDK0zpLNq91Ogz1IXnVBAYV7fCFAJ/zIxU0RiIBrJIOll/C0pR9Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.9.6",
+    "@cloudflare/workers-types": "^4.20250317.0",
     "@eslint/js": "9.25.1",
     "@getmocha/users-service": "^0.0.4",
     "@getmocha/vite-plugins": "latest",

--- a/src/react-app/types/getmocha-users-service.d.ts
+++ b/src/react-app/types/getmocha-users-service.d.ts
@@ -1,0 +1,12 @@
+import type { MochaUser as BaseMochaUser } from '@getmocha/users-service/shared';
+
+declare module '@getmocha/users-service/shared' {
+  interface MochaUser {
+    google_user_data: BaseMochaUser['google_user_data'] & {
+      name?: string | null;
+      given_name?: string | null;
+      family_name?: string | null;
+      picture?: string | null;
+    };
+  }
+}

--- a/src/react-app/vite-env.d.ts
+++ b/src/react-app/vite-env.d.ts
@@ -1,1 +1,3 @@
+/// <reference types="react" />
+/// <reference types="react-dom" />
 /// <reference types="vite/client" />

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -2,11 +2,11 @@
   "extends": "./tsconfig.node.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
-    "types": ["vite/client"],
+    "types": ["@cloudflare/workers-types", "vite/client"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/worker", "worker-configuration.d.ts"]
+  "include": ["src/worker"]
 }


### PR DESCRIPTION
## Summary
- ensure React JSX types are available by referencing react and react-dom in the vite env declaration file
- add module augmentation for MochaUser to surface optional Google profile fields used by the UI
- add Cloudflare worker type definitions and update the worker tsconfig to rely on them instead of the generated file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d35ee3b89c832f8d49ef26d0d92f22