### PR TITLE
Fix missing React and Mocha type definitions

### DIFF
--- a/src/react-app/types/getmocha-users-service.d.ts
+++ b/src/react-app/types/getmocha-users-service.d.ts
@@ -2,6 +2,7 @@ import type { MochaUser as BaseMochaUser } from '@getmocha/users-service/shared'
 
 declare module '@getmocha/users-service/shared' {
   interface MochaUser {
+    name?: string | null;
     google_user_data: BaseMochaUser['google_user_data'] & {
       name?: string | null;
       given_name?: string | null;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,6 +11,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
+    "types": ["react", "react-dom", "vite/client"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- ensure the app TypeScript config explicitly includes React and Vite ambient type definitions to satisfy JSX usage
- augment the Mocha user module declaration so the optional `name` field is available when consuming `useAuth`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d363639908832f85bcd77c63ee02a8