### PR TITLE
Ensure local type definitions are picked up during builds

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -12,6 +12,7 @@
       "@/*": ["./src/*"]
     },
     "types": ["react", "react-dom", "vite/client"],
+    "typeRoots": ["./src/react-app/types", "./node_modules/@types"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -8,5 +8,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/worker"]
+  "include": ["src/worker", "worker-configuration.d.ts"]
 }


### PR DESCRIPTION
## Summary
- extend the application TypeScript project configuration to include the local `src/react-app/types` folder in the compiler `typeRoots`
- include `worker-configuration.d.ts` in the worker TypeScript project so its generated definitions are available during compilation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d36613fd70832f98978136f903c993