### PR TITLE
Refresh marketing home with light Contable-inspired theme

### DIFF
--- a/src/react-app/components/layout/ExperienceOverlay.tsx
+++ b/src/react-app/components/layout/ExperienceOverlay.tsx
@@ -44,7 +44,7 @@ export default function ExperienceOverlay({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8">
       <div
-        className="absolute inset-0 bg-slate-950/80 backdrop-blur-xl"
+        className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
         aria-hidden="true"
         onClick={onClose}
       />
@@ -52,14 +52,14 @@ export default function ExperienceOverlay({
         role="dialog"
         aria-modal
         aria-labelledby="experience-overlay-title"
-        className="relative w-full max-w-5xl overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-2xl backdrop-blur-2xl glass-surface"
+        className="relative w-full max-w-5xl overflow-hidden rounded-3xl border border-emerald-100 bg-white p-6 shadow-2xl"
       >
-        <div className="absolute -top-40 -left-32 h-80 w-80 rounded-full bg-emerald-500/20 blur-3xl" aria-hidden="true" />
-        <div className="absolute -bottom-32 -right-20 h-72 w-72 rounded-full bg-cyan-500/20 blur-3xl" aria-hidden="true" />
+        <div className="absolute -top-40 -left-32 h-80 w-80 rounded-full bg-emerald-100 blur-3xl" aria-hidden="true" />
+        <div className="absolute -bottom-32 -right-20 h-72 w-72 rounded-full bg-cyan-100 blur-3xl" aria-hidden="true" />
         <button
           type="button"
           onClick={onClose}
-          className="absolute right-6 top-6 rounded-full border border-white/10 bg-white/10 p-2 text-white transition hover:bg-white/20"
+          className="absolute right-6 top-6 rounded-full border border-emerald-100 bg-white p-2 text-slate-500 transition hover:bg-emerald-50 hover:text-emerald-700"
           aria-label="Fechar visualização"
         >
           <X className="h-5 w-5" />
@@ -69,16 +69,16 @@ export default function ExperienceOverlay({
           <div className="flex flex-col gap-4 pr-12 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex items-start gap-4">
               {Icon && (
-                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-500 via-sky-500 to-blue-600 text-white shadow-lg">
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-400 via-teal-400 to-sky-500 text-white shadow-lg">
                   <Icon className="h-6 w-6" />
                 </span>
               )}
               <div>
-                <h2 id="experience-overlay-title" className="text-2xl font-semibold text-white">
+                <h2 id="experience-overlay-title" className="text-2xl font-semibold text-slate-900">
                   {title}
                 </h2>
                 {description && (
-                  <p className="mt-2 max-w-2xl text-sm text-slate-200/80">
+                  <p className="mt-2 max-w-2xl text-sm text-slate-600">
                     {description}
                   </p>
                 )}

--- a/src/react-app/components/sections/CallToActionSection.tsx
+++ b/src/react-app/components/sections/CallToActionSection.tsx
@@ -8,20 +8,20 @@ interface CallToActionSectionProps {
 export default function CallToActionSection({ onOpenOverlay }: CallToActionSectionProps) {
   return (
     <section className="relative mt-24 pb-20 text-left">
-      <div className="absolute inset-x-0 -bottom-40 -z-10 h-[400px] bg-gradient-to-b from-emerald-500/20 via-transparent to-transparent blur-3xl" aria-hidden="true" />
-      <div className="overflow-hidden rounded-4xl border border-white/10 bg-slate-900/70 p-10 shadow-2xl backdrop-blur-xl glass-surface">
-        <div className="absolute -left-20 top-1/2 h-48 w-48 -translate-y-1/2 rounded-full bg-emerald-500/30 blur-3xl" aria-hidden="true" />
-        <div className="absolute -right-16 -top-24 h-64 w-64 rounded-full bg-cyan-500/20 blur-3xl" aria-hidden="true" />
+      <div className="absolute inset-x-0 -bottom-40 -z-10 h-[400px] bg-gradient-to-b from-emerald-100 via-transparent to-transparent blur-3xl" aria-hidden="true" />
+      <div className="overflow-hidden rounded-4xl border border-emerald-100 bg-white p-10 shadow-2xl">
+        <div className="absolute -left-20 top-1/2 h-48 w-48 -translate-y-1/2 rounded-full bg-emerald-100 blur-3xl" aria-hidden="true" />
+        <div className="absolute -right-16 -top-24 h-64 w-64 rounded-full bg-cyan-100 blur-3xl" aria-hidden="true" />
         <div className="relative flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
           <div className="max-w-2xl">
-            <div className="flex items-center gap-3 text-emerald-200/80">
+            <div className="flex items-center gap-3 text-emerald-600">
               <Shield className="h-5 w-5" />
               <span className="text-sm font-medium uppercase tracking-[0.3em]">Segurança e autonomia</span>
             </div>
-            <h2 className="mt-6 text-3xl font-semibold text-white sm:text-4xl">
+            <h2 className="mt-6 text-3xl font-semibold text-slate-900 sm:text-4xl">
               Aprofunde sua estratégia financeira com experiências guiadas, seguras e personalizadas.
             </h2>
-            <p className="mt-4 text-base text-slate-200/80">
+            <p className="mt-4 text-base text-slate-600">
               Continue explorando dashboards completos, cadastre novas despesas ou conecte instituições para desbloquear a automação total.
             </p>
           </div>
@@ -29,7 +29,7 @@ export default function CallToActionSection({ onOpenOverlay }: CallToActionSecti
             <button
               type="button"
               onClick={() => onOpenOverlay('dashboard')}
-              className="inline-flex items-center justify-between gap-4 rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-cyan-500 px-6 py-3 text-left text-base font-semibold text-slate-900 shadow-lg transition hover:shadow-xl"
+              className="inline-flex items-center justify-between gap-4 rounded-full bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-6 py-3 text-left text-base font-semibold text-white shadow-lg transition hover:shadow-xl"
             >
               Abrir painel financeiro completo
               <ArrowRight className="h-5 w-5" />
@@ -37,7 +37,7 @@ export default function CallToActionSection({ onOpenOverlay }: CallToActionSecti
             <button
               type="button"
               onClick={() => onOpenOverlay('quick-actions')}
-              className="inline-flex items-center justify-between gap-4 rounded-full border border-white/10 bg-white/10 px-6 py-3 text-left text-base font-medium text-white transition hover:bg-white/20"
+              className="inline-flex items-center justify-between gap-4 rounded-full border border-emerald-100 bg-white px-6 py-3 text-left text-base font-medium text-emerald-700 transition hover:bg-emerald-50"
             >
               Acessar ações rápidas
               <ArrowRight className="h-5 w-5" />

--- a/src/react-app/components/sections/FeatureHighlights.tsx
+++ b/src/react-app/components/sections/FeatureHighlights.tsx
@@ -15,14 +15,14 @@ export default function FeatureHighlights({ items }: FeatureHighlightsProps) {
   return (
     <section aria-labelledby="feature-highlights" className="relative">
       <div className="mb-12 flex flex-col gap-4 text-left">
-        <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-medium uppercase tracking-[0.2em] text-emerald-200/80">
+        <span className="inline-flex w-fit items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-4 py-1 text-xs font-medium uppercase tracking-[0.2em] text-emerald-600">
           Experiências Financeiras
         </span>
         <div className="max-w-2xl">
-          <h2 id="feature-highlights" className="text-3xl font-semibold text-white sm:text-4xl">
+          <h2 id="feature-highlights" className="text-3xl font-semibold text-slate-900 sm:text-4xl">
             Tudo o que você precisa para navegar seu dinheiro com clareza
           </h2>
-          <p className="mt-4 text-base text-slate-200/80">
+          <p className="mt-4 text-base text-slate-600">
             Explore camadas de informações, automações inteligentes e uma visão unificada das suas contas em um fluxo contínuo.
           </p>
         </div>
@@ -32,7 +32,7 @@ export default function FeatureHighlights({ items }: FeatureHighlightsProps) {
         {items.map(({ icon: Icon, title, description, accent }) => (
           <article
             key={title}
-            className="group relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-transparent p-6 text-left shadow-lg transition-transform hover:-translate-y-1 hover:shadow-2xl glass-surface"
+            className="group relative overflow-hidden rounded-3xl border border-emerald-100/60 bg-white p-6 text-left shadow-lg transition-transform hover:-translate-y-1 hover:shadow-2xl"
           >
             <div
               className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
@@ -42,11 +42,11 @@ export default function FeatureHighlights({ items }: FeatureHighlightsProps) {
               }}
             />
             <div className="relative flex flex-col gap-4">
-              <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/10 text-white shadow-inner">
+              <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-emerald-100 bg-emerald-50 text-emerald-700 shadow-inner">
                 <Icon className="h-6 w-6" />
               </span>
-              <h3 className="text-lg font-semibold text-white">{title}</h3>
-              <p className="text-sm text-slate-200/70">{description}</p>
+              <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+              <p className="text-sm text-slate-600">{description}</p>
             </div>
           </article>
         ))}

--- a/src/react-app/components/sections/FinancePreviewSection.tsx
+++ b/src/react-app/components/sections/FinancePreviewSection.tsx
@@ -93,16 +93,16 @@ export default function FinancePreviewSection({
 
   return (
     <section className="relative mt-24" aria-labelledby="finance-preview">
-      <div className="absolute inset-0 -z-10 rounded-[3rem] bg-gradient-to-br from-emerald-500/10 via-cyan-500/5 to-transparent" aria-hidden="true" />
+      <div className="absolute inset-0 -z-10 rounded-[3rem] bg-gradient-to-br from-emerald-100 via-cyan-50 to-transparent" aria-hidden="true" />
       <div className="flex flex-col gap-12 text-left">
         <div className="flex flex-col gap-4">
-          <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-emerald-500/10 px-4 py-1 text-xs font-medium uppercase tracking-[0.2em] text-emerald-200/90">
+          <span className="inline-flex w-fit items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-4 py-1 text-xs font-medium uppercase tracking-[0.2em] text-emerald-600">
             Visualização Imersiva
           </span>
-          <h2 id="finance-preview" className="max-w-3xl text-3xl font-semibold text-white sm:text-4xl">
+          <h2 id="finance-preview" className="max-w-3xl text-3xl font-semibold text-slate-900 sm:text-4xl">
             Explore camadas de dados, dashboards e integrações sem sair do fluxo
           </h2>
-          <p className="max-w-2xl text-base text-slate-200/80">
+          <p className="max-w-2xl text-base text-slate-600">
             Visualize tendências, abra painéis completos e conecte instituições com uma experiência fluida, inspirada em interfaces imersivas.
           </p>
         </div>
@@ -111,28 +111,28 @@ export default function FinancePreviewSection({
           {previewCards.map(({ id, title, description, icon: Icon, highlight, detail }) => (
             <article
               key={id}
-              className="group relative overflow-hidden rounded-4xl border border-white/10 bg-slate-900/60 p-8 shadow-2xl backdrop-blur-xl transition-transform hover:-translate-y-1 hover:shadow-3xl glass-surface"
+              className="group relative overflow-hidden rounded-4xl border border-emerald-100 bg-white p-8 shadow-xl transition-transform hover:-translate-y-1 hover:shadow-2xl"
             >
-              <div className="absolute -top-32 right-0 h-72 w-72 rounded-full bg-emerald-500/20 opacity-0 blur-3xl transition-opacity duration-300 group-hover:opacity-100" aria-hidden="true" />
+              <div className="absolute -top-32 right-0 h-72 w-72 rounded-full bg-emerald-100 opacity-0 blur-3xl transition-opacity duration-300 group-hover:opacity-100" aria-hidden="true" />
               <div className="relative flex flex-col gap-6">
                 <div className="flex items-center gap-4">
-                  <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/10 text-white">
+                  <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-emerald-100 bg-emerald-50 text-emerald-700">
                     <Icon className="h-6 w-6" />
                   </span>
                   <div>
-                    <h3 className="text-2xl font-semibold text-white">{title}</h3>
-                    <p className="mt-1 text-sm text-emerald-200/80">{highlight}</p>
+                    <h3 className="text-2xl font-semibold text-slate-900">{title}</h3>
+                    <p className="mt-1 text-sm text-emerald-600">{highlight}</p>
                   </div>
                 </div>
-                <p className="text-base text-slate-200/80">{description}</p>
-                <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-sm text-slate-100/80">
+                <p className="text-base text-slate-600">{description}</p>
+                <div className="rounded-3xl border border-emerald-100 bg-emerald-50/70 p-4 text-sm text-slate-600">
                   {detail}
                 </div>
                 <div>
                   <button
                     type="button"
                     onClick={() => onOpenOverlay(id)}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-5 py-2 text-sm font-medium text-white transition hover:bg-emerald-500/20"
+                    className="inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-white px-5 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50"
                   >
                     Abrir experiência
                     <ArrowUpRight className="h-4 w-4" />
@@ -143,15 +143,15 @@ export default function FinancePreviewSection({
           ))}
         </div>
 
-        <div className="rounded-4xl border border-white/10 bg-white/5 p-6 text-left shadow-xl backdrop-blur-xl glass-surface">
+        <div className="rounded-4xl border border-emerald-100 bg-white p-6 text-left shadow-xl">
           <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
             <div>
-              <h3 className="text-lg font-semibold text-white">Outras ferramentas disponíveis</h3>
-              <p className="text-sm text-slate-200/70">
+              <h3 className="text-lg font-semibold text-slate-900">Outras ferramentas disponíveis</h3>
+              <p className="text-sm text-slate-600">
                 Abra painéis completos ou fluxos específicos com um clique.
               </p>
             </div>
-            <div className="rounded-full border border-white/10 bg-emerald-500/20 px-4 py-1 text-xs font-medium uppercase tracking-[0.3em] text-emerald-200/90">
+            <div className="rounded-full border border-emerald-100 bg-emerald-50 px-4 py-1 text-xs font-medium uppercase tracking-[0.3em] text-emerald-600">
               +{Math.max(0, quickLinks.length - 4)} experiências
             </div>
           </div>
@@ -161,15 +161,15 @@ export default function FinancePreviewSection({
                 key={id}
                 type="button"
                 onClick={() => onOpenOverlay(id)}
-                className="group flex items-center justify-between gap-3 rounded-3xl border border-white/10 bg-slate-900/40 px-4 py-3 text-left text-sm font-medium text-slate-100/80 transition hover:bg-emerald-500/10 hover:text-white"
+                className="group flex items-center justify-between gap-3 rounded-3xl border border-emerald-100 bg-white px-4 py-3 text-left text-sm font-medium text-slate-600 transition hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700"
               >
                 <span className="flex items-center gap-3">
-                  <span className="flex h-9 w-9 items-center justify-center rounded-2xl border border-white/10 bg-white/10 text-white">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-2xl border border-emerald-100 bg-emerald-50 text-emerald-700">
                     <Icon className="h-4 w-4" />
                   </span>
                   {label}
                 </span>
-                <ArrowUpRight className="h-4 w-4 opacity-0 transition group-hover:opacity-100" />
+                <ArrowUpRight className="h-4 w-4 text-emerald-500 opacity-0 transition group-hover:opacity-100" />
               </button>
             ))}
           </div>

--- a/src/react-app/components/sections/HeroSection.tsx
+++ b/src/react-app/components/sections/HeroSection.tsx
@@ -22,25 +22,25 @@ export default function HeroSection({
 
   return (
     <section className="relative pb-24 pt-20 text-left">
-      <div className="absolute inset-x-0 top-0 -z-10 flex h-[480px] justify-center overflow-hidden" aria-hidden="true">
+      <div className="absolute inset-x-0 top-0 -z-10 flex h-[520px] justify-center overflow-hidden" aria-hidden="true">
         <div className="aurora-gradient" />
       </div>
 
-      <nav className="relative mb-16 flex items-center justify-between gap-6">
+      <nav className="relative mb-16 flex items-center justify-between gap-6 rounded-full border border-emerald-100/70 bg-white/80 px-6 py-4 shadow-xl backdrop-blur">
         <div className="flex items-center gap-4">
-          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-white shadow-lg">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-400 to-teal-500 text-white shadow-md">
             <Wallet className="h-6 w-6" />
           </div>
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200/80">Financeito</p>
-            <p className="text-sm text-slate-200/80">Fluxo financeiro com IA generativa</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-600">Financeito</p>
+            <p className="text-sm text-slate-600">Fluxo financeiro com IA generativa</p>
           </div>
         </div>
         <div className="flex items-center gap-3">
           <button
             type="button"
             onClick={onRefreshInsights}
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20"
+            className="inline-flex items-center gap-2 rounded-full border border-emerald-100/80 bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-100"
           >
             <RefreshCw className="h-4 w-4" />
             Atualizar insights
@@ -49,17 +49,17 @@ export default function HeroSection({
         </div>
       </nav>
 
-      <div className="relative grid items-center gap-16 lg:grid-cols-[1.1fr_1fr]">
+      <div className="relative grid items-center gap-16 lg:grid-cols-[1.05fr_1fr]">
         <div className="flex flex-col gap-10">
           <div className="flex flex-col gap-6">
-            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-medium uppercase tracking-[0.4em] text-emerald-200/80">
-              Nova experiência imersiva
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-4 py-1 text-xs font-medium uppercase tracking-[0.4em] text-emerald-600">
+              Nova jornada financeira
             </span>
-            <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-[3.5rem] lg:leading-[1.05]">
+            <h1 className="text-4xl font-semibold leading-tight text-slate-900 sm:text-5xl lg:text-[3.5rem] lg:leading-[1.05]">
               Controle financeiro com IA, agora em um fluxo contínuo
               {firstName ? `, ${firstName}` : ''}.
             </h1>
-            <p className="max-w-2xl text-lg text-slate-200/85">
+            <p className="max-w-2xl text-lg text-slate-600">
               Uma jornada hero-led que conecta seus gastos, insights automáticos e integrações Open Finance em um layout vertical envolvente.
             </p>
           </div>
@@ -68,7 +68,7 @@ export default function HeroSection({
             <button
               type="button"
               onClick={() => onOpenOverlay('expense-tracker')}
-              className="inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-cyan-500 px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:shadow-xl"
+              className="inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:shadow-xl"
             >
               Registrar gasto agora
               <Sparkles className="h-4 w-4" />
@@ -76,62 +76,62 @@ export default function HeroSection({
             <button
               type="button"
               onClick={() => onOpenOverlay('insights')}
-              className="inline-flex items-center gap-3 rounded-full border border-white/15 bg-white/10 px-6 py-3 text-sm font-medium text-white transition hover:bg-white/20"
+              className="inline-flex items-center gap-3 rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-medium text-slate-700 transition hover:border-emerald-200 hover:text-emerald-700"
             >
               Ver insights de IA
             </button>
           </div>
 
           <dl className="grid gap-4 sm:grid-cols-2">
-            <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur-xl glass-surface">
-              <dt className="text-sm font-medium text-emerald-200/80">Monitorado neste mês</dt>
-              <dd className="text-2xl font-semibold text-white">{formatCurrency(thisMonthExpenses)}</dd>
-              <p className="text-xs text-slate-200/70">Capture gastos recorrentes e receba alertas automáticos.</p>
+            <div className="flex flex-col gap-3 rounded-3xl border border-emerald-100 bg-white p-6 shadow-lg">
+              <dt className="text-sm font-medium text-emerald-600">Monitorado neste mês</dt>
+              <dd className="text-2xl font-semibold text-slate-900">{formatCurrency(thisMonthExpenses)}</dd>
+              <p className="text-xs text-slate-500">Capture gastos recorrentes e receba alertas automáticos.</p>
             </div>
-            <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur-xl glass-surface">
-              <dt className="text-sm font-medium text-emerald-200/80">Total acompanhado</dt>
-              <dd className="text-2xl font-semibold text-white">{formatCurrency(totalExpenses)}</dd>
-              <p className="text-xs text-slate-200/70">Centralize contas, cartões e investimentos em uma única visão.</p>
+            <div className="flex flex-col gap-3 rounded-3xl border border-emerald-100 bg-white p-6 shadow-lg">
+              <dt className="text-sm font-medium text-emerald-600">Total acompanhado</dt>
+              <dd className="text-2xl font-semibold text-slate-900">{formatCurrency(totalExpenses)}</dd>
+              <p className="text-xs text-slate-500">Centralize contas, cartões e investimentos em uma única visão.</p>
             </div>
           </dl>
         </div>
 
         <div className="relative hidden min-h-[420px] items-center justify-center lg:flex">
-          <div className="absolute inset-0 -z-10 animate-pulse-slow rounded-full bg-emerald-500/20 blur-3xl" aria-hidden="true" />
+          <div className="absolute inset-0 -z-10 animate-pulse-slow rounded-full bg-emerald-200/50 blur-3xl" aria-hidden="true" />
           <div className="relative flex w-full max-w-md flex-col gap-6">
-            <div className="layered-card">
+            <div className="rounded-3xl border border-emerald-100 bg-white p-6 shadow-2xl">
               <div className="flex items-center justify-between">
-                <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-xs font-medium text-emerald-100">Resumo diário</span>
-                <span className="text-xs text-white/60">IA ativa</span>
+                <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">Resumo diário</span>
+                <span className="text-xs text-slate-400">IA ativa</span>
               </div>
               <div className="mt-6 space-y-4">
                 <div>
-                  <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/70">Este mês</p>
-                  <p className="mt-1 text-3xl font-semibold text-white">{formatCurrency(thisMonthExpenses)}</p>
+                  <p className="text-xs uppercase tracking-[0.3em] text-emerald-500">Este mês</p>
+                  <p className="mt-1 text-3xl font-semibold text-slate-900">{formatCurrency(thisMonthExpenses)}</p>
                 </div>
-                <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-                  <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/60">Recomendação</p>
-                  <p className="mt-2 text-sm text-white/80">
+                <div className="rounded-2xl border border-emerald-100 bg-emerald-50/80 p-4">
+                  <p className="text-xs uppercase tracking-[0.3em] text-emerald-500">Recomendação</p>
+                  <p className="mt-2 text-sm text-slate-600">
                     Ajuste o orçamento da categoria com maior crescimento e abra os insights completos para sugestões personalizadas.
                   </p>
                 </div>
               </div>
             </div>
-            <div className="layered-card translate-x-8 border-white/5 bg-white/10">
-              <div className="flex items-center justify-between text-sm text-white/70">
+            <div className="translate-x-8 rounded-3xl border border-emerald-100 bg-gradient-to-br from-white to-emerald-50 p-6 shadow-xl">
+              <div className="flex items-center justify-between text-sm text-slate-600">
                 <span>Contas conectadas</span>
                 <button
                   type="button"
                   onClick={() => onOpenOverlay('banking')}
-                  className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs text-white transition hover:bg-white/20"
+                  className="rounded-full border border-emerald-100 bg-white px-3 py-1 text-xs font-medium text-emerald-700 transition hover:bg-emerald-100"
                 >
                   Abrir Open Finance
                 </button>
               </div>
-              <div className="mt-5 space-y-3 text-sm text-white/70">
+              <div className="mt-5 space-y-3 text-sm text-slate-600">
                 <p>Carteira digital • sincronização em tempo real</p>
                 <p>Cartões vinculados • monitoramento de limites</p>
-                <p className="text-xs text-emerald-200/80">Nova integração disponível para investimentos.</p>
+                <p className="text-xs text-emerald-500">Nova integração disponível para investimentos.</p>
               </div>
             </div>
           </div>

--- a/src/react-app/index.css
+++ b/src/react-app/index.css
@@ -65,13 +65,10 @@
 }
 
 body {
-  background: radial-gradient(circle at 20% 20%, rgba(16, 185, 129, 0.2), transparent 45%),
-    radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.2), transparent 45%),
-    radial-gradient(circle at 50% 80%, rgba(59, 130, 246, 0.15), transparent 45%),
-    #020617;
-  color: #f8fafc;
+  background: linear-gradient(180deg, #f3faf5 0%, #ffffff 35%, #f8fbff 100%);
+  color: #0f172a;
   min-height: 100vh;
-  color-scheme: dark;
+  color-scheme: light;
 }
 
 /* Paper texture background */
@@ -127,17 +124,17 @@ body {
   width: 140%;
   height: 100%;
   background:
-    radial-gradient(circle at 20% 20%, rgba(16, 185, 129, 0.35), transparent 55%),
-    radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.25), transparent 45%),
-    radial-gradient(circle at 50% 100%, rgba(59, 130, 246, 0.2), transparent 55%);
-  filter: blur(60px);
-  opacity: 0.9;
+    radial-gradient(circle at 20% 20%, rgba(110, 231, 183, 0.45), transparent 55%),
+    radial-gradient(circle at 75% 10%, rgba(56, 189, 248, 0.35), transparent 45%),
+    radial-gradient(circle at 40% 80%, rgba(59, 130, 246, 0.25), transparent 55%);
+  filter: blur(80px);
+  opacity: 0.8;
 }
 
 .glass-surface {
   position: relative;
   backdrop-filter: blur(24px);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(148, 163, 184, 0.08));
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(226, 232, 240, 0.65));
 }
 
 .glass-surface::before {
@@ -145,7 +142,7 @@ body {
   position: absolute;
   inset: 1px;
   border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(148, 163, 184, 0.25);
   pointer-events: none;
 }
 
@@ -153,11 +150,11 @@ body {
   position: relative;
   border-radius: 24px;
   padding: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(15, 118, 110, 0.3));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(209, 250, 229, 0.7));
   backdrop-filter: blur(20px);
-  box-shadow: 0 25px 60px -20px rgba(15, 118, 110, 0.35);
-  color: #f8fafc;
+  box-shadow: 0 25px 60px -20px rgba(56, 189, 248, 0.25);
+  color: #0f172a;
 }
 
 .layered-card::after {
@@ -165,7 +162,7 @@ body {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.25);
   pointer-events: none;
 }
 

--- a/src/react-app/pages/Home.tsx
+++ b/src/react-app/pages/Home.tsx
@@ -77,17 +77,17 @@ export default function Home() {
   }
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-b from-emerald-50 via-white to-white text-slate-900">
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div
-          className="absolute left-1/2 top-[-10%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-emerald-500/20 blur-3xl"
+          className="absolute left-1/2 top-[-20%] h-[540px] w-[540px] -translate-x-1/2 rounded-full bg-emerald-200/40 blur-3xl"
           aria-hidden="true"
         />
         <div
-          className="absolute right-[-10%] bottom-0 h-[520px] w-[520px] rounded-full bg-cyan-500/20 blur-3xl"
+          className="absolute right-[-15%] bottom-[-10%] h-[520px] w-[520px] rounded-full bg-cyan-200/40 blur-3xl"
           aria-hidden="true"
         />
-        <div className="bg-grid" aria-hidden="true" />
+        <div className="bg-grid opacity-50" aria-hidden="true" />
       </div>
 
       <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-24 px-4 pb-24 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- switch the home experience to a bright gradient base with softer ambient effects to match the requested style
- restyle hero, feature highlight, and finance preview sections with white surfaces, teal accents, and refreshed CTAs while keeping live metrics
- update the call-to-action panel and experience overlay visuals to follow the new light palette

## Testing
- npm run lint *(fails: pre-existing lint errors around `any` usage and unused variables in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3785f8260832f910c8a6141213f0c