### PR TITLE
Ensure dist root contains static assets for Vercel deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "scripts": {
     "build": "tsc -b && vite build",
+    "postbuild": "node scripts/postbuild.js",
     "cf-typegen": "wrangler types",
     "check": "tsc && vite build && wrangler deploy --dry-run",
     "dev": "vite",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,22 @@
+import { cpSync, existsSync, readdirSync, statSync } from "fs";
+import path from "path";
+
+const distDir = path.resolve("dist");
+const clientDir = path.join(distDir, "client");
+
+if (!existsSync(clientDir)) {
+  console.log("[postbuild] dist/client not found, skipping copy.");
+  process.exit(0);
+}
+
+console.log("[postbuild] Copying client assets to dist root for deployment platforms that expect dist/index.html.");
+
+for (const entry of readdirSync(clientDir)) {
+  const src = path.join(clientDir, entry);
+  const dest = path.join(distDir, entry);
+  const stats = statSync(src);
+
+  cpSync(src, dest, { recursive: stats.isDirectory(), force: true });
+}
+
+console.log("[postbuild] Copy complete.");


### PR DESCRIPTION
## Summary
- add a postbuild script that copies the Vite client output into the dist root so Vercel can find index.html
- wire the new postbuild step into the build script to keep Cloudflare assets untouched while exposing dist/index.html

## Testing
- npm run build
- npm run lint *(fails: existing lint errors throughout the project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d37d6de204832f92a96b748c99d191