### PR TITLE
Update Clerk integration for latest SDK

### DIFF
--- a/src/react-app/components/AuthButton.tsx
+++ b/src/react-app/components/AuthButton.tsx
@@ -55,7 +55,7 @@ export default function AuthButton() {
   }
 
   return (
-    <SignInButton mode="modal" afterSignInUrl="/" afterSignUpUrl="/">
+    <SignInButton mode="modal" forceRedirectUrl="/" signUpForceRedirectUrl="/">
       <button className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-emerald-500 to-teal-600 text-white rounded-xl font-semibold hover:from-emerald-600 hover:to-teal-700 transition-all duration-200 shadow-lg hover:shadow-xl">
         <GoogleIcon />
         Entrar ou criar conta

--- a/src/react-app/components/LoginPrompt.tsx
+++ b/src/react-app/components/LoginPrompt.tsx
@@ -52,7 +52,7 @@ export default function LoginPrompt() {
             </div>
           </div>
 
-          <SignInButton mode="modal" afterSignInUrl="/" afterSignUpUrl="/">
+          <SignInButton mode="modal" forceRedirectUrl="/" signUpForceRedirectUrl="/">
             <button className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-gradient-to-r from-emerald-500 to-teal-600 text-white rounded-xl font-semibold hover:from-emerald-600 hover:to-teal-700 transition-all duration-200 shadow-lg hover:shadow-xl">
               <GoogleIcon />
               Entrar ou criar conta


### PR DESCRIPTION
## Summary
- update Clerk sign-in buttons to use the new redirect props
- adapt the worker authentication middleware to the current `authenticateRequest` API and derive the user id via `toAuth`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d38d8313ec832fb265529ec4ceb2cd