### PR TITLE
feat: enhance card visuals and bank branding

### DIFF
--- a/src/react-app/components/AccountManager.tsx
+++ b/src/react-app/components/AccountManager.tsx
@@ -1,6 +1,23 @@
 import { useState, useEffect } from 'react';
-import { Plus, Building2, CreditCard, Wallet, TrendingUp, Banknote, Edit, Trash2, RefreshCw, Eye, EyeOff } from 'lucide-react';
+import {
+  Plus,
+  Building2,
+  CreditCard,
+  Wallet,
+  TrendingUp,
+  Banknote,
+  Edit,
+  Trash2,
+  RefreshCw,
+  Eye,
+  EyeOff,
+  Check,
+} from 'lucide-react';
 import { Account, CreateAccount } from '@/shared/types';
+import {
+  bankOptionsForForm,
+  getBankVisualConfig,
+} from '@/react-app/components/brand/FinancialBrandAssets';
 
 const ACCOUNT_TYPE_ICONS = {
   checking: Wallet,
@@ -317,6 +334,46 @@ export default function AccountManager() {
                 />
               </div>
 
+              <div className="md:col-span-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium text-gray-700">Escolha uma instituição</p>
+                  <span className="text-xs uppercase tracking-[0.3em] text-gray-400">Opcional</span>
+                </div>
+                <div className="mt-3 grid gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                  {bankOptionsForForm.map(option => {
+                    const Logo = option.logo;
+                    const isSelected = option.keywords.some(keyword =>
+                      formData.institution_name?.toLowerCase().includes(keyword)
+                    );
+
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setFormData(prev => ({ ...prev, institution_name: option.label }))}
+                        className={`group relative flex flex-col items-center gap-3 rounded-2xl border px-3 py-3 transition ${
+                          isSelected
+                            ? 'border-blue-500 bg-blue-50 shadow-sm'
+                            : 'border-gray-200 bg-white hover:border-blue-200 hover:bg-blue-50/60'
+                        }`}
+                      >
+                        <span
+                          className={`flex h-16 w-full items-center justify-center rounded-2xl bg-gradient-to-br ${option.badgeGradient} text-white shadow-inner`}
+                        >
+                          <Logo className="h-8 text-white" />
+                        </span>
+                        <span className="text-sm font-medium text-gray-700">{option.label}</span>
+                        {isSelected && (
+                          <span className="absolute right-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg">
+                            <Check className="h-3.5 w-3.5" />
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Saldo Inicial
@@ -369,7 +426,7 @@ export default function AccountManager() {
         )}
 
         {/* Accounts List */}
-        <div className="space-y-4">
+        <div className="space-y-5">
           {accounts.length === 0 ? (
             <div className="text-center py-12">
               <Building2 className="w-16 h-16 text-gray-400 mx-auto mb-4" />
@@ -379,32 +436,54 @@ export default function AccountManager() {
           ) : (
             accounts.map((account) => {
               const Icon = ACCOUNT_TYPE_ICONS[account.account_type];
-              const colorClass = ACCOUNT_TYPE_COLORS[account.account_type];
+              const bankVisual = getBankVisualConfig(
+                account.institution_name || account.marketing_name || account.name
+              );
+              const BankLogo = bankVisual.logo;
+              const hasCustomBank = bankVisual.id !== 'default';
+              const institutionDisplay = account.institution_name || (hasCustomBank ? bankVisual.label : null);
               return (
                 <div
                   key={account.id}
-                  className={`bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl p-6 border border-gray-200 ${
+                  className={`rounded-4xl border border-slate-200 bg-white/90 p-6 shadow-lg transition ${
                     account.is_active ? '' : 'opacity-60'
                   }`}
                 >
                   <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-4">
-                        <div className={`bg-gradient-to-br ${colorClass} p-3 rounded-xl`}>
-                          <Icon className="w-6 h-6 text-white" />
+                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                      <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                        <div className="flex items-center justify-center">
+                          {hasCustomBank ? (
+                            <span
+                              className={`flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br ${bankVisual.badgeGradient} text-white shadow-inner`}
+                            >
+                              <BankLogo className="h-9 text-white" />
+                            </span>
+                          ) : (
+                            <span
+                              className={`flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br ${ACCOUNT_TYPE_COLORS[account.account_type]} text-white shadow-inner`}
+                            >
+                              <Icon className="h-7 w-7 text-white" />
+                            </span>
+                          )}
                         </div>
                         <div>
-                          <h3 className="font-bold text-gray-900">{account.name}</h3>
+                          <h3 className="text-lg font-semibold text-gray-900">{account.name}</h3>
                           {account.marketing_name && account.marketing_name !== account.name && (
                             <p className="text-sm text-blue-600">{account.marketing_name}</p>
                           )}
-                          <div className="flex items-center gap-4 text-sm text-gray-600">
+                          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-600">
                             <span>{ACCOUNT_TYPE_LABELS[account.account_type]}</span>
-                            {account.institution_name && (
-                              <span>• {account.institution_name}</span>
+                            {institutionDisplay && (
+                              <>
+                                <span className="text-gray-400">•</span>
+                                <span className="font-medium text-gray-700">{institutionDisplay}</span>
+                              </>
                             )}
                             {account.pluggy_account_id && (
-                              <span className="text-green-600">• Pluggy conectado</span>
+                              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-600">
+                                <Check className="h-3.5 w-3.5" /> Pluggy conectado
+                              </span>
                             )}
                           </div>
                           {account.number && (
@@ -415,7 +494,7 @@ export default function AccountManager() {
                           )}
                         </div>
                       </div>
-                      
+
                       <div className="flex items-center gap-4">
                         <div className="text-right">
                           <p className="text-xl font-bold text-gray-900">
@@ -427,7 +506,7 @@ export default function AccountManager() {
                             </p>
                           )}
                         </div>
-                        
+
                         <div className="flex items-center gap-2">
                           <button
                             onClick={() => handleEdit(account)}

--- a/src/react-app/components/CreditCardManager.tsx
+++ b/src/react-app/components/CreditCardManager.tsx
@@ -1,7 +1,24 @@
 import { useState, useEffect } from 'react';
-import { Plus, CreditCard, Edit, Trash2, Calendar, DollarSign, Link, RefreshCw, Unlink, CheckCircle, AlertCircle, FileText } from 'lucide-react';
+import {
+  Plus,
+  CreditCard,
+  Edit,
+  Trash2,
+  Calendar,
+  DollarSign,
+  Link,
+  RefreshCw,
+  Unlink,
+  CheckCircle,
+  AlertCircle,
+  FileText,
+} from 'lucide-react';
 import { CreditCard as CreditCardType, CreateCreditCard } from '@/shared/types';
 import CreditCardBillManager from './CreditCardBillManager';
+import {
+  getCardNetworkVisual,
+  getCardVisualConfig,
+} from '@/react-app/components/brand/FinancialBrandAssets';
 
 interface ExtendedCreditCard extends CreditCardType {
   linked_account_id?: number;
@@ -446,7 +463,7 @@ export default function CreditCardManager() {
         )}
 
         {/* Cards List */}
-        <div className="space-y-4">
+        <div className="space-y-6">
           {cards.length === 0 ? (
             <div className="text-center py-12">
               <CreditCard className="w-16 h-16 text-gray-400 mx-auto mb-4" />
@@ -455,185 +472,231 @@ export default function CreditCardManager() {
             </div>
           ) : (
             cards.map((card) => {
-              const currentBalance = card.linked_account_balance ? Math.abs(card.linked_account_balance) : card.current_balance;
+              const currentBalance = card.linked_account_balance
+                ? Math.abs(card.linked_account_balance)
+                : card.current_balance;
               const creditLimit = card.linked_credit_limit || card.credit_limit;
+              const availableCredit = card.linked_available_credit
+                ? card.linked_available_credit
+                : creditLimit - currentBalance;
               const utilizationPercent = getUtilizationPercentage(currentBalance, creditLimit);
-              return (
-                <div
-                  key={card.id}
-                  className="bg-gradient-to-r from-blue-50 to-blue-100 rounded-xl p-6 border border-blue-200"
-                >
-                  <div className="flex items-center justify-between mb-4">
-                    <div className="flex items-center gap-3">
-                      <CreditCard className="w-8 h-8 text-blue-600" />
-                      <div>
-                        <div className="flex items-center gap-2 mb-1">
-                          <h3 className="font-bold text-gray-900">{card.name}</h3>
-                          {card.linked_account_id ? (
-                            <div className="flex items-center gap-1 px-2 py-1 bg-green-100 text-green-700 rounded-full text-xs">
-                              <CheckCircle className="w-3 h-3" />
-                              Pluggy
-                            </div>
-                          ) : (
-                            <div className="flex items-center gap-1 px-2 py-1 bg-gray-100 text-gray-600 rounded-full text-xs">
-                              <AlertCircle className="w-3 h-3" />
-                              Manual
-                            </div>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2 text-sm text-gray-600">
-                          <Calendar className="w-4 h-4" />
-                          <span>Vence dia {card.due_day}</span>
-                          {card.linked_account_name && (
-                            <>
-                              <span>•</span>
-                              <span className="text-green-600">{card.linked_account_name}</span>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                    
-                    <div className="flex items-center gap-2">
-                      {card.linked_account_id ? (
-                        <>
-                          <button
-                            onClick={() => handleSyncCard(card.id)}
-                            disabled={syncingCard === card.id}
-                            className="p-2 text-green-600 hover:bg-green-100 rounded-lg transition-colors disabled:opacity-50"
-                            title="Sincronizar dados do Pluggy"
-                          >
-                            <RefreshCw className={`w-4 h-4 ${syncingCard === card.id ? 'animate-spin' : ''}`} />
-                          </button>
-                          <button
-                            onClick={() => handleUnlinkCard(card.id)}
-                            className="p-2 text-orange-600 hover:bg-orange-100 rounded-lg transition-colors"
-                            title="Desvincular conta Pluggy"
-                          >
-                            <Unlink className="w-4 h-4" />
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          onClick={() => handleLinkCard(card)}
-                          className="p-2 text-blue-600 hover:bg-blue-100 rounded-lg transition-colors"
-                          title="Vincular com conta Pluggy"
-                        >
-                          <Link className="w-4 h-4" />
-                        </button>
-                      )}
-                      <button
-                        onClick={() => handleEdit(card)}
-                        className="p-2 text-blue-600 hover:bg-blue-200 rounded-lg transition-colors"
-                      >
-                        <Edit className="w-4 h-4" />
-                      </button>
-                      <button
-                        onClick={() => handleDelete(card.id)}
-                        className="p-2 text-red-600 hover:bg-red-100 rounded-lg transition-colors"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </div>
+              const cardVisual = getCardVisualConfig(card.name || card.linked_account_name);
+              const networkVisual = getCardNetworkVisual(card.name, cardVisual.defaultNetwork);
+              const IssuerLogo = cardVisual.issuerLogo;
+              const NetworkLogo = networkVisual.logo;
+              const isDarkCard = cardVisual.accent.includes('text-white');
+              const mutedText = isDarkCard ? 'text-white/70' : 'text-slate-600';
+              const statusBadgeClass = card.linked_account_id
+                ? isDarkCard
+                  ? 'border border-emerald-200/50 bg-emerald-400/20 text-emerald-100'
+                  : 'border border-emerald-200 bg-emerald-100 text-emerald-700'
+                : isDarkCard
+                  ? 'border border-white/30 bg-white/15 text-white/90'
+                  : 'border border-slate-200 bg-slate-100 text-slate-700';
+              const actionButtonClass = isDarkCard
+                ? 'rounded-full bg-white/15 p-2 text-white transition hover:bg-white/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80'
+                : 'rounded-full bg-slate-900/10 p-2 text-slate-900 transition hover:bg-slate-900/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-600/40';
+              const highlightBadgeClass = isDarkCard
+                ? 'border border-white/25 bg-white/15 text-white'
+                : 'border border-slate-200 bg-white/80 text-slate-900';
 
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div className="bg-white rounded-lg p-4">
-                      <div className="flex items-center gap-2 mb-2">
-                        <DollarSign className="w-5 h-5 text-green-600" />
-                        <span className="text-sm font-medium text-gray-600">Limite Total</span>
+              return (
+                <div key={card.id} className="rounded-4xl border border-slate-100 bg-white/90 p-6 shadow-xl">
+                  <article
+                    className={`relative overflow-hidden rounded-[28px] bg-gradient-to-br ${cardVisual.gradient} ${cardVisual.accent} p-6 shadow-2xl`}
+                  >
+                    <div className="absolute inset-0">
+                      <div
+                        className={`absolute -top-16 -right-12 h-40 w-40 rounded-full bg-gradient-to-br ${cardVisual.patternColor} opacity-70 blur-3xl`}
+                        aria-hidden="true"
+                      />
+                      <div
+                        className={`absolute -bottom-20 left-[-10%] h-48 w-48 rounded-full bg-gradient-to-br ${cardVisual.highlightGradient} opacity-60 blur-3xl`}
+                        aria-hidden="true"
+                      />
+                    </div>
+
+                    <div className="relative flex flex-col gap-6">
+                      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="space-y-4">
+                          <IssuerLogo className={`h-7 ${isDarkCard ? 'text-white' : 'text-slate-900'}`} />
+                          <div
+                            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.3em] ${statusBadgeClass}`}
+                          >
+                            {card.linked_account_id ? (
+                              <>
+                                <CheckCircle className="h-3.5 w-3.5" />
+                                Sincronizado
+                              </>
+                            ) : (
+                              <>
+                                <AlertCircle className="h-3.5 w-3.5" />
+                                Manual
+                              </>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className="flex flex-col items-end gap-3">
+                          <NetworkLogo className={`h-6 ${isDarkCard ? 'text-white' : 'text-slate-900'}`} />
+                          <div className="flex items-center gap-2">
+                            {card.linked_account_id ? (
+                              <>
+                                <button
+                                  onClick={() => handleSyncCard(card.id)}
+                                  disabled={syncingCard === card.id}
+                                  className={`${actionButtonClass} disabled:opacity-50`}
+                                  title="Sincronizar dados do Pluggy"
+                                >
+                                  <RefreshCw className={`h-4 w-4 ${syncingCard === card.id ? 'animate-spin' : ''}`} />
+                                </button>
+                                <button
+                                  onClick={() => handleUnlinkCard(card.id)}
+                                  className={actionButtonClass}
+                                  title="Desvincular conta Pluggy"
+                                >
+                                  <Unlink className="h-4 w-4" />
+                                </button>
+                              </>
+                            ) : (
+                              <button
+                                onClick={() => handleLinkCard(card)}
+                                className={actionButtonClass}
+                                title="Vincular com conta Pluggy"
+                              >
+                                <Link className="h-4 w-4" />
+                              </button>
+                            )}
+                            <button onClick={() => handleEdit(card)} className={actionButtonClass} title="Editar cartão">
+                              <Edit className="h-4 w-4" />
+                            </button>
+                            <button onClick={() => handleDelete(card.id)} className={actionButtonClass} title="Excluir cartão">
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </div>
+                        </div>
                       </div>
-                      <p className="text-xl font-bold text-gray-900">
+
+                      <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+                        <div>
+                          <p className={`text-xs uppercase tracking-[0.35em] ${mutedText}`}>Fatura atual</p>
+                          <p className="mt-2 text-3xl font-semibold">
+                            {formatCurrency(currentBalance)}
+                          </p>
+                        </div>
+                        <div
+                          className={`inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-medium ${highlightBadgeClass}`}
+                        >
+                          <Calendar className="h-4 w-4" />
+                          Vence dia {card.due_day}
+                        </div>
+                      </div>
+
+                      <div className="grid gap-4 text-sm sm:grid-cols-3">
+                        <div>
+                          <p className={`text-[0.7rem] uppercase tracking-[0.3em] ${mutedText}`}>Limite total</p>
+                          <p className="mt-2 text-lg font-semibold">
+                            {formatCurrency(card.linked_credit_limit || card.credit_limit)}
+                          </p>
+                        </div>
+                        <div>
+                          <p className={`text-[0.7rem] uppercase tracking-[0.3em] ${mutedText}`}>Saldo atual</p>
+                          <p className="mt-2 text-lg font-semibold">{formatCurrency(currentBalance)}</p>
+                        </div>
+                        <div>
+                          <p className={`text-[0.7rem] uppercase tracking-[0.3em] ${mutedText}`}>Disponível</p>
+                          <p className="mt-2 text-lg font-semibold">{formatCurrency(Math.max(0, availableCredit))}</p>
+                        </div>
+                      </div>
+
+                      <div>
+                        <p className={`text-[0.7rem] uppercase tracking-[0.3em] ${mutedText}`}>Cartão</p>
+                        <p className="mt-2 text-base font-semibold">{card.name}</p>
+                        {card.linked_account_name ? (
+                          <p className={`text-xs ${mutedText}`}>Integrado com {card.linked_account_name}</p>
+                        ) : (
+                          <p className={`text-xs ${mutedText}`}>Cadastro manual</p>
+                        )}
+                      </div>
+                    </div>
+                  </article>
+
+                  <div className="mt-6 grid gap-4 md:grid-cols-3">
+                    <div className="rounded-2xl border border-slate-100 bg-white/80 p-4 shadow-sm">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                        <DollarSign className="h-4 w-4 text-emerald-500" />
+                        Limite total
+                      </div>
+                      <p className="mt-2 text-xl font-semibold text-slate-900">
                         {formatCurrency(card.linked_credit_limit || card.credit_limit)}
                       </p>
                       {card.linked_credit_limit && card.linked_credit_limit !== card.credit_limit && (
-                        <p className="text-xs text-green-600">
-                          (Sincronizado: {formatCurrency(card.linked_credit_limit)})
+                        <p className="mt-1 text-xs text-emerald-600">
+                          Sincronizado: {formatCurrency(card.linked_credit_limit)}
                         </p>
                       )}
                     </div>
-
-                    <div className="bg-white rounded-lg p-4">
-                      <div className="flex items-center gap-2 mb-2">
-                        <DollarSign className="w-5 h-5 text-red-600" />
-                        <span className="text-sm font-medium text-gray-600">Saldo Atual</span>
+                    <div className="rounded-2xl border border-slate-100 bg-white/80 p-4 shadow-sm">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                        <DollarSign className="h-4 w-4 text-rose-500" />
+                        Saldo atual
                       </div>
-                      <p className="text-xl font-bold text-gray-900">
-                        {formatCurrency(card.linked_account_balance ? Math.abs(card.linked_account_balance) : card.current_balance)}
-                      </p>
+                      <p className="mt-2 text-xl font-semibold text-slate-900">{formatCurrency(currentBalance)}</p>
                       {card.linked_account_balance && Math.abs(card.linked_account_balance) !== card.current_balance && (
-                        <p className="text-xs text-red-600">
-                          (Sincronizado: {formatCurrency(Math.abs(card.linked_account_balance))})
+                        <p className="mt-1 text-xs text-rose-500">
+                          Sincronizado: {formatCurrency(Math.abs(card.linked_account_balance))}
                         </p>
                       )}
                     </div>
-
-                    <div className="bg-white rounded-lg p-4">
-                      <div className="flex items-center gap-2 mb-2">
-                        <DollarSign className="w-5 h-5 text-blue-600" />
-                        <span className="text-sm font-medium text-gray-600">Limite Disponível</span>
+                    <div className="rounded-2xl border border-slate-100 bg-white/80 p-4 shadow-sm">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                        <DollarSign className="h-4 w-4 text-blue-500" />
+                        Disponível
                       </div>
-                      <p className="text-xl font-bold text-gray-900">
-                        {card.linked_available_credit ? 
-                          formatCurrency(card.linked_available_credit) :
-                          formatCurrency((card.linked_credit_limit || card.credit_limit) - (card.linked_account_balance ? Math.abs(card.linked_account_balance) : card.current_balance))
-                        }
+                      <p className="mt-2 text-xl font-semibold text-slate-900">
+                        {formatCurrency(Math.max(0, availableCredit))}
                       </p>
                       {card.linked_available_credit && (
-                        <p className="text-xs text-blue-600">
-                          (Pluggy: {formatCurrency(card.linked_available_credit)})
+                        <p className="mt-1 text-xs text-blue-600">
+                          Pluggy: {formatCurrency(card.linked_available_credit)}
                         </p>
                       )}
                     </div>
                   </div>
 
-                  {/* Pluggy Sync Status */}
                   {card.linked_account_id && (
-                    <div className="mt-4 p-3 bg-green-50 rounded-lg border border-green-200">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <CheckCircle className="w-4 h-4 text-green-600" />
-                          <span className="text-sm font-medium text-green-800">
-                            Vinculado com {card.linked_account_name}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          {card.linked_minimum_payment && (
-                            <span className="text-xs text-green-700">
-                              Pagamento mín: {formatCurrency(card.linked_minimum_payment)}
-                            </span>
-                          )}
-                          {card.linked_due_date && (
-                            <span className="text-xs text-green-700">
-                              Vence: {new Date(card.linked_due_date).toLocaleDateString('pt-BR')}
-                            </span>
-                          )}
-                        </div>
+                    <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-emerald-100 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-700">
+                      <div className="flex items-center gap-2 font-medium">
+                        <CheckCircle className="h-4 w-4" /> Vinculado com {card.linked_account_name}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-3 text-xs">
+                        {card.linked_minimum_payment && (
+                          <span>Pagamento mín.: {formatCurrency(card.linked_minimum_payment)}</span>
+                        )}
+                        {card.linked_due_date && (
+                          <span>Vence: {new Date(card.linked_due_date).toLocaleDateString('pt-BR')}</span>
+                        )}
                       </div>
                     </div>
                   )}
 
-                  {/* Utilization Bar */}
                   <div className="mt-4">
-                    <div className="flex items-center justify-between mb-2">
-                      <span className="text-sm font-medium text-gray-600">Utilização do Limite</span>
-                      <span className={`text-sm font-bold px-2 py-1 rounded-full ${getUtilizationColor(utilizationPercent)}`}>
+                    <div className="flex items-center justify-between text-sm font-medium text-slate-600">
+                      <span>Utilização do limite</span>
+                      <span className={`rounded-full px-3 py-1 ${getUtilizationColor(utilizationPercent)}`}>
                         {utilizationPercent.toFixed(1)}%
                       </span>
                     </div>
-                    <div className="w-full bg-gray-200 rounded-full h-2">
+                    <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-slate-200">
                       <div
                         className={`h-2 rounded-full transition-all ${
-                          utilizationPercent >= 80 ? 'bg-red-500' :
-                          utilizationPercent >= 60 ? 'bg-yellow-500' : 'bg-green-500'
+                          utilizationPercent >= 80 ? 'bg-red-500' : utilizationPercent >= 60 ? 'bg-yellow-500' : 'bg-green-500'
                         }`}
                         style={{ width: `${Math.min(utilizationPercent, 100)}%` }}
-                      ></div>
+                      />
                     </div>
                     {card.linked_account_id && (
-                      <p className="text-xs text-gray-500 mt-1">
-                        Dados sincronizados automaticamente do Pluggy
-                      </p>
+                      <p className="mt-2 text-xs text-slate-500">Dados sincronizados automaticamente do Pluggy</p>
                     )}
                   </div>
                 </div>

--- a/src/react-app/components/brand/FinancialBrandAssets.tsx
+++ b/src/react-app/components/brand/FinancialBrandAssets.tsx
@@ -1,0 +1,401 @@
+import type { ComponentType } from 'react';
+
+export type LogoProps = { className?: string };
+
+const createTextLogo = (
+  text: string,
+  options?: { fontSize?: number; letterSpacing?: number; fontWeight?: number }
+): ComponentType<LogoProps> => {
+  const { fontSize = 14, letterSpacing = 0, fontWeight = 600 } = options || {};
+  const Component = ({ className }: LogoProps) => (
+    <svg viewBox="0 0 64 24" className={className} role="img" aria-hidden="true">
+      <text
+        x="50%"
+        y="52%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        fill="currentColor"
+        fontFamily="'Inter', 'Segoe UI', sans-serif"
+        fontSize={fontSize}
+        fontWeight={fontWeight}
+        letterSpacing={letterSpacing}
+      >
+        {text}
+      </text>
+    </svg>
+  );
+  Component.displayName = `${text.replace(/\s+/g, '')}Logo`;
+  return Component;
+};
+
+const NubankWordmark = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 68 32" className={className} role="img" aria-hidden="true">
+    <path
+      d="M6.1 27.6c-3.3 0-4.6-2.2-4.6-5.6V9.3C1.5 5.8 3 3.4 6.5 3.4c2 0 3.8.9 5.1 2.5V3.9h5.4v23.7h-5.4V16.1c0-3.5-1.4-5.2-3.6-5.2-1.6 0-2.4.8-2.4 2.9v8.7c0 2.1.7 2.9 2.4 2.9h.7v4.2h-2.6zM36.8 27.6c-2.7 0-4.8-1.1-6.2-3.3v3h-5.4V3.9h5.4v7.5c1.4-2.2 3.5-3.3 6.2-3.3 4.2 0 6.5 2.6 6.5 6.9v5.7c0 4.3-2.3 6.9-6.5 6.9zm-1.6-16c-1.8 0-3.2 1-3.2 3.6v5.1c0 2.6 1.4 3.6 3.2 3.6s3.2-1 3.2-3.6v-5.1c0-2.6-1.4-3.6-3.2-3.6z"
+      fill="currentColor"
+    />
+  </svg>
+);
+NubankWordmark.displayName = 'NubankLogo';
+
+const BradescoMark = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 64 64" className={className} role="img" aria-hidden="true">
+    <defs>
+      <linearGradient id="bradescoGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+        <stop offset="0%" stopColor="#ff5f6d" />
+        <stop offset="100%" stopColor="#ff1f3d" />
+      </linearGradient>
+    </defs>
+    <rect width="64" height="64" rx="16" fill="url(#bradescoGradient)" />
+    <path
+      d="M32 18c-6.5 0-11.5 3.1-13.8 8.6h4.9c1.8-3.1 4.7-4.5 8.9-4.5 4.8 0 8.4 2.4 8.4 7 0 3.3-2 6.3-6.4 6.3-2.5 0-4.6-1-6.2-2.5l-3.9 2.2V46h5.2v-7.6c1.6 1 3.4 1.5 5.4 1.5 7 0 11.8-4.8 11.8-11.8C45.3 22.3 39.8 18 32 18z"
+      fill="#fff"
+    />
+    <circle cx="32" cy="46" r="5" fill="#fff" />
+  </svg>
+);
+BradescoMark.displayName = 'BradescoLogo';
+
+const ItauWordmark = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 64 64" className={className} role="img" aria-hidden="true">
+    <rect width="64" height="64" rx="18" fill="#003399" />
+    <rect x="4" y="4" width="56" height="56" rx="14" fill="#ff8c00" />
+    <text
+      x="32"
+      y="37"
+      textAnchor="middle"
+      fill="#003399"
+      fontFamily="'Inter', 'Segoe UI', sans-serif"
+      fontSize="20"
+      fontWeight="700"
+    >
+      Itaú
+    </text>
+  </svg>
+);
+ItauWordmark.displayName = 'ItauLogo';
+
+const BancoDoBrasilMark = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 64 64" className={className} role="img" aria-hidden="true">
+    <rect width="64" height="64" rx="16" fill="#ffd400" />
+    <path
+      d="M46 20.5 32 29.7 18 20.5l6.8-4.4L32 21l7.2-4.9L46 20.5zm0 23L32 34.3 18 43.5l6.8 4.4L32 43l7.2 4.9 6.8-4.4zm-14-9.5 7.2 4.9 6.8-4.4-14-9.2-14 9.2 6.8 4.4 7.2-4.9z"
+      fill="#003399"
+    />
+  </svg>
+);
+BancoDoBrasilMark.displayName = 'BancoDoBrasilLogo';
+
+const SantanderMark = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 64 64" className={className} role="img" aria-hidden="true">
+    <rect width="64" height="64" rx="16" fill="#ed1b24" />
+    <path
+      d="M33.8 17c.6 4.3-.7 6.9-2.5 10.3-1.5 2.9-3.1 6.2-2.4 10.5 1.2-1.8 3.7-3.1 6-3.1 3.7 0 6.7 2.6 6.7 6.3 0 4.7-4 6.9-8.7 6.9-5.9 0-10.7-3.4-10.7-8.6 0-3.7 2-6.3 4.1-9 2.6-3.5 5.3-7.3 3.9-13.3 1.2.3 2.6.6 3.6 1z"
+      fill="#fff"
+    />
+  </svg>
+);
+SantanderMark.displayName = 'SantanderLogo';
+
+const CaixaMark = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 64 64" className={className} role="img" aria-hidden="true">
+    <rect width="64" height="64" rx="16" fill="#003399" />
+    <path d="M14 20h12l6 8-6 8H14l6-8-6-8z" fill="#f7941d" />
+    <path d="M38 20h12l-6 8 6 8H38l-6-8 6-8z" fill="#f7941d" opacity="0.8" />
+  </svg>
+);
+CaixaMark.displayName = 'CaixaLogo';
+
+const InterWordmark = createTextLogo('Inter', { fontSize: 16, fontWeight: 700 });
+const PicPayWordmark = createTextLogo('PicPay', { fontSize: 16, fontWeight: 700 });
+const C6Wordmark = createTextLogo('C6 Bank', { fontSize: 14, fontWeight: 600 });
+
+const VisaLogo = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 80 24" className={className} role="img" aria-hidden="true">
+    <path d="M34.2 23.4h-6.2l3.9-22.9h6.2l-3.9 22.9zm-9.4-22.9-6 15.7-.7-3.5-2.1-10.8S14.8.5 12.3.5H1.2L1 1.4s3.5.8 6.1 3.6c2.9 2.8 3.8 4.7 3.8 4.7l4.8 13.7h6.5l10-22.9h-7.4zM52.6 6.5c-2.7-1.3-4.5-2.2-4.5-3.4.1-1.2 1.4-2 4.5-2 2.5-.1 4.5.4 6 .8l.7.2 1-5.6C58.9-.3 56.2-.9 53 1c-6.3 3-6.3 10.5-2.3 13.7 2.2 1.8 5.5 2.8 4.8 4.6-.4 2-3.3 1.9-6.3 1.8-1.5 0-2.7-.2-3.5-.3l-.8-.2-1.1 6.1c1.4.3 3.5.5 5.9.5 6.2 0 10.2-3 10.2-7.6.1-5.7-7.9-6.1-7.3-8.1.2-1.4 2.2-1.5 4.1-1.5 1.4 0 2.7.2 3.5.4l.7.1.7-5.8c-.9-.3-2.5-.8-5.6-.8-5.8-.2-9.7 2.7-9.8 7.2 0 3.2 3 5 5.3 6 2.3 1.1 3.1 1.8 3 2.9-.1 1.5-1.9 2.2-3.7 2.2-2.5 0-3.9-.4-5-.8l-.7-.2-.9 5.7c1.2.3 3.2.6 5.4.6 5.6 0 9.7-2.8 9.8-7.2.1-5.3-6.9-5.7-6.8-7.9.1-1.1 1.4-1.4 3.3-1.4 1.7 0 2.9.3 3.8.5l.6.1.9-5.6c-1.2-.3-2.9-.7-5.1-.7-6.5 0-9.6 3.1-9.7 6.6z"
+      fill="currentColor"
+    />
+  </svg>
+);
+VisaLogo.displayName = 'VisaLogo';
+
+const MastercardLogo = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 72 24" className={className} role="img" aria-hidden="true">
+    <circle cx="27" cy="12" r="10" fill="#eb001b" />
+    <circle cx="45" cy="12" r="10" fill="#f79e1b" />
+    <path d="M33 12a9.9 9.9 0 0 1 4.5-8.3 9.9 9.9 0 0 0 0 16.6A9.9 9.9 0 0 1 33 12z" fill="#ff5f00" />
+  </svg>
+);
+MastercardLogo.displayName = 'MastercardLogo';
+
+const EloLogo = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 64 24" className={className} role="img" aria-hidden="true">
+    <circle cx="12" cy="12" r="10" fill="#231f20" />
+    <path d="M11.8 7.2 9 9.5l2.8 2.3 2.8-2.3-2.8-2.3z" fill="#00a8e0" />
+    <path d="M11.8 16.8 9 14.5l2.8-2.3 2.8 2.3-2.8 2.3z" fill="#f6b800" />
+    <path d="M19 12c0-3.3 2.7-6 6-6s6 2.7 6 6-2.7 6-6 6" stroke="#231f20" strokeWidth="3" fill="none" />
+  </svg>
+);
+EloLogo.displayName = 'EloLogo';
+
+const AmexLogo = ({ className }: LogoProps) => (
+  <svg viewBox="0 0 96 28" className={className} role="img" aria-hidden="true">
+    <rect width="96" height="28" rx="6" fill="#2678b6" />
+    <text
+      x="48"
+      y="18"
+      textAnchor="middle"
+      fill="#fff"
+      fontFamily="'Inter', 'Segoe UI', sans-serif"
+      fontSize="12"
+      fontWeight="700"
+      letterSpacing="3"
+    >
+      AMEX
+    </text>
+  </svg>
+);
+AmexLogo.displayName = 'AmexLogo';
+
+const DefaultNetworkLogo = createTextLogo('Card', { fontSize: 12, fontWeight: 600 });
+
+export type CardNetworkId = 'visa' | 'mastercard' | 'elo' | 'amex' | 'default';
+
+const CARD_NETWORKS: Record<CardNetworkId, { label: string; logo: ComponentType<LogoProps> }> = {
+  visa: { label: 'Visa', logo: VisaLogo },
+  mastercard: { label: 'Mastercard', logo: MastercardLogo },
+  elo: { label: 'Elo', logo: EloLogo },
+  amex: { label: 'American Express', logo: AmexLogo },
+  default: { label: 'Cartão', logo: DefaultNetworkLogo },
+};
+
+const CARD_NETWORK_KEYWORDS: { id: CardNetworkId; keywords: string[] }[] = [
+  { id: 'visa', keywords: ['visa'] },
+  { id: 'mastercard', keywords: ['mastercard', 'master card'] },
+  { id: 'elo', keywords: ['elo'] },
+  { id: 'amex', keywords: ['amex', 'american express'] },
+];
+
+export interface CardVisualConfig {
+  id: string;
+  label: string;
+  keywords: string[];
+  gradient: string;
+  accent: string;
+  patternColor: string;
+  highlightGradient: string;
+  issuerLogo: ComponentType<LogoProps>;
+  defaultNetwork?: CardNetworkId;
+}
+
+const CARD_VISUALS: CardVisualConfig[] = [
+  {
+    id: 'nubank',
+    label: 'Nubank',
+    keywords: ['nubank', 'nu bank', 'roxo'],
+    gradient: 'from-[#3b0d72] via-[#5d15a3] to-[#8c3fff]',
+    accent: 'text-white',
+    patternColor: 'from-white/10 via-white/5 to-transparent',
+    highlightGradient: 'from-white/25 to-white/10',
+    issuerLogo: NubankWordmark,
+    defaultNetwork: 'mastercard',
+  },
+  {
+    id: 'itau',
+    label: 'Itaú',
+    keywords: ['itau', 'itaú'],
+    gradient: 'from-[#00205b] via-[#003399] to-[#fd8b2c]',
+    accent: 'text-white',
+    patternColor: 'from-white/20 via-white/10 to-transparent',
+    highlightGradient: 'from-white/35 to-white/10',
+    issuerLogo: ItauWordmark,
+    defaultNetwork: 'visa',
+  },
+  {
+    id: 'bradesco',
+    label: 'Bradesco',
+    keywords: ['bradesco'],
+    gradient: 'from-[#6b0f1a] via-[#b91350] to-[#f93d66]',
+    accent: 'text-white',
+    patternColor: 'from-white/25 via-white/10 to-transparent',
+    highlightGradient: 'from-white/25 to-white/5',
+    issuerLogo: BradescoMark,
+    defaultNetwork: 'visa',
+  },
+  {
+    id: 'santander',
+    label: 'Santander',
+    keywords: ['santander'],
+    gradient: 'from-[#7b0006] via-[#c50712] to-[#ff3043]',
+    accent: 'text-white',
+    patternColor: 'from-white/20 via-white/10 to-transparent',
+    highlightGradient: 'from-white/30 to-white/5',
+    issuerLogo: SantanderMark,
+    defaultNetwork: 'visa',
+  },
+  {
+    id: 'caixa',
+    label: 'Caixa',
+    keywords: ['caixa'],
+    gradient: 'from-[#002878] via-[#003e9f] to-[#007bff]',
+    accent: 'text-white',
+    patternColor: 'from-white/15 via-white/8 to-transparent',
+    highlightGradient: 'from-white/20 to-white/5',
+    issuerLogo: CaixaMark,
+    defaultNetwork: 'elo',
+  },
+  {
+    id: 'c6',
+    label: 'C6 Bank',
+    keywords: ['c6'],
+    gradient: 'from-[#1c1c1c] via-[#2f2f2f] to-[#4a4a4a]',
+    accent: 'text-white',
+    patternColor: 'from-white/20 via-white/5 to-transparent',
+    highlightGradient: 'from-white/15 to-white/5',
+    issuerLogo: C6Wordmark,
+    defaultNetwork: 'mastercard',
+  },
+  {
+    id: 'inter',
+    label: 'Inter',
+    keywords: ['inter'],
+    gradient: 'from-[#f97316] via-[#fb923c] to-[#fdba74]',
+    accent: 'text-slate-900',
+    patternColor: 'from-white/40 via-white/30 to-transparent',
+    highlightGradient: 'from-white/40 to-white/10',
+    issuerLogo: InterWordmark,
+    defaultNetwork: 'visa',
+  },
+];
+
+const fallbackCardVisual: CardVisualConfig = {
+  id: 'default',
+  label: 'Cartão',
+  keywords: [],
+  gradient: 'from-slate-800 via-slate-900 to-slate-950',
+  accent: 'text-white',
+  patternColor: 'from-white/10 via-white/5 to-transparent',
+  highlightGradient: 'from-white/20 to-white/5',
+  issuerLogo: createTextLogo('Card', { fontSize: 12 }),
+  defaultNetwork: 'default',
+};
+
+export const POPULAR_BANK_BRANDS = [
+  {
+    id: 'nubank',
+    label: 'Nubank',
+    keywords: ['nubank', 'nu'],
+    badgeGradient: 'from-[#7e22ce] via-[#8b5cf6] to-[#a855f7]',
+    logo: NubankWordmark,
+  },
+  {
+    id: 'itau',
+    label: 'Itaú',
+    keywords: ['itau', 'itaú'],
+    badgeGradient: 'from-[#ffb347] via-[#fd8b2c] to-[#ff6a00]',
+    logo: ItauWordmark,
+  },
+  {
+    id: 'bradesco',
+    label: 'Bradesco',
+    keywords: ['bradesco'],
+    badgeGradient: 'from-[#f97373] via-[#ef4444] to-[#dc2626]',
+    logo: BradescoMark,
+  },
+  {
+    id: 'banco-do-brasil',
+    label: 'Banco do Brasil',
+    keywords: ['banco do brasil', 'bb'],
+    badgeGradient: 'from-[#facc15] via-[#fbbf24] to-[#f59e0b]',
+    logo: BancoDoBrasilMark,
+  },
+  {
+    id: 'santander',
+    label: 'Santander',
+    keywords: ['santander'],
+    badgeGradient: 'from-[#ef4444] via-[#dc2626] to-[#b91c1c]',
+    logo: SantanderMark,
+  },
+  {
+    id: 'caixa',
+    label: 'Caixa',
+    keywords: ['caixa'],
+    badgeGradient: 'from-[#3b82f6] via-[#2563eb] to-[#1d4ed8]',
+    logo: CaixaMark,
+  },
+  {
+    id: 'inter',
+    label: 'Inter',
+    keywords: ['inter'],
+    badgeGradient: 'from-[#fb923c] via-[#f97316] to-[#ea580c]',
+    logo: InterWordmark,
+  },
+  {
+    id: 'picpay',
+    label: 'PicPay',
+    keywords: ['picpay'],
+    badgeGradient: 'from-[#34d399] via-[#10b981] to-[#047857]',
+    logo: PicPayWordmark,
+  },
+  {
+    id: 'c6',
+    label: 'C6 Bank',
+    keywords: ['c6'],
+    badgeGradient: 'from-[#4b5563] via-[#374151] to-[#111827]',
+    logo: C6Wordmark,
+  },
+];
+
+export interface BankVisualConfig {
+  id: string;
+  label: string;
+  keywords: string[];
+  badgeGradient: string;
+  logo: ComponentType<LogoProps>;
+}
+
+const fallbackBankVisual: BankVisualConfig = {
+  id: 'default',
+  label: 'Instituição',
+  keywords: [],
+  badgeGradient: 'from-slate-200 via-slate-300 to-slate-400',
+  logo: createTextLogo('Bank', { fontSize: 12 }),
+};
+
+export const getCardVisualConfig = (name?: string | null): CardVisualConfig => {
+  if (!name) return fallbackCardVisual;
+  const normalized = name.toLowerCase();
+  return (
+    CARD_VISUALS.find(visual => visual.keywords.some(keyword => normalized.includes(keyword))) || fallbackCardVisual
+  );
+};
+
+export const getBankVisualConfig = (name?: string | null): BankVisualConfig => {
+  if (!name) return fallbackBankVisual;
+  const normalized = name.toLowerCase();
+  return (
+    POPULAR_BANK_BRANDS.find(visual => visual.keywords.some(keyword => normalized.includes(keyword))) || fallbackBankVisual
+  );
+};
+
+export const getCardNetworkVisual = (
+  name?: string | null,
+  fallback?: CardNetworkId
+): { id: CardNetworkId; label: string; logo: ComponentType<LogoProps> } => {
+  const normalized = name?.toLowerCase() ?? '';
+  const detected = CARD_NETWORK_KEYWORDS.find(network =>
+    network.keywords.some(keyword => normalized.includes(keyword))
+  );
+  const networkId = detected?.id || fallback || 'default';
+  return CARD_NETWORKS[networkId];
+};
+
+export const resolveAvailableBankOption = (value?: string | null) => {
+  if (!value) return null;
+  const normalized = value.toLowerCase();
+  return POPULAR_BANK_BRANDS.find(option => option.keywords.some(keyword => normalized.includes(keyword))) || null;
+};
+
+export const bankOptionsForForm = POPULAR_BANK_BRANDS.slice(0, 8);
+
+export type LogoRenderer = ComponentType<LogoProps>;


### PR DESCRIPTION
## Summary
- create reusable financial brand assets to provide issuer and bank logos, gradients, and badge metadata
- restyle the credit card manager to render cards with physical aesthetics, branded actions, and refreshed stat blocks
- allow choosing popular bank logos when creating accounts and surface those badges across the account list

## Testing
- npm run lint *(fails: existing lint errors from other files using `any` types and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68d38fbca174832fa576acf2048e9892