### PR TITLE
Add SPA fallback routing for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration that falls back to index.html so SPA routes like Clerk callbacks resolve correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d457926f70832fb558d6fb0c20b14e