### PR TITLE
Fix router import for BrowserRouter

### DIFF
--- a/src/react-app/App.tsx
+++ b/src/react-app/App.tsx
@@ -1,10 +1,10 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ClerkLoaded, ClerkLoading } from "@clerk/clerk-react";
 import HomePage from "@/react-app/pages/Home";
 
 export default function App() {
   return (
-    <Router>
+    <BrowserRouter>
       <ClerkLoading>
         <div className="min-h-screen bg-slate-950 flex items-center justify-center">
           <div className="animate-pulse">
@@ -17,6 +17,6 @@ export default function App() {
           <Route path="/" element={<HomePage />} />
         </Routes>
       </ClerkLoaded>
-    </Router>
+    </BrowserRouter>
   );
 }


### PR DESCRIPTION
## Summary
- import BrowserRouter from `react-router-dom` instead of the core `react-router` package
- wrap the app with `<BrowserRouter>` so the router renders correctly instead of crashing at runtime

## Testing
- `npm run lint` *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d495c893e8832f893b79f40332cf51