### PR TITLE
Fix missing react-router-dom dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-router": "^7.5.3",
+        "react-router-dom": "^7.9.2",
         "recharts": "^3.1.0",
         "tailwind-merge": "^3.3.1",
         "zod": "^3.24.3"
@@ -5393,9 +5394,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
-      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.2.tgz",
+      "integrity": "sha512-i2TPp4dgaqrOqiRGLZmqh2WXmbdFknUyiCRmSKs0hf6fWXkTKg5h56b+9F22NbGRAMxjYfqQnpi63egzD2SuZA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5412,6 +5413,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.2.tgz",
+      "integrity": "sha512-pagqpVJnjZOfb+vIM23eTp7Sp/AAJjOgaowhP1f1TWOdk5/W8Uk8d/M/0wfleqx7SgjitjNPPsKeCZE1hTSp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-router": "^7.5.3",
+    "react-router-dom": "^7.9.2",
     "recharts": "^3.1.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.24.3"


### PR DESCRIPTION
## Summary
- add react-router-dom as a production dependency so the router components in App.tsx resolve at build time
- update the lockfile to include react-router-dom and the matching react-router version

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d498d28e0c832fbfb855a547bef3a5